### PR TITLE
Refactor grocery form submit via vuex

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,3 +23,11 @@ This document started at v0.7.0, via the `itemForm` branch.
   - create new state (props) and getter (computed props)
   - create mutations and actions to update state
   - update components
+- ending point: v0.8.1
+
+3. Use vuex instead of props for submitting the grocery form
+
+- starting branch: grocery-form-control-vuex
+- starting point: v0.8.1
+- ending point: v0.8.2
+- refactor `TheGroceryForm.vue` and `TheGroceryFormControls.vue` to use vuex to submit form from the form controls instead of using custom events to submit via the form parent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Rewrite of my groceries web app in Vue and Parcel",
   "main": "index.pug",
   "scripts": {

--- a/src/components/GroceryForm/TheGroceryForm.vue
+++ b/src/components/GroceryForm/TheGroceryForm.vue
@@ -8,43 +8,26 @@
         ></GroceryFormItem>
       </template>
     </ol>
-    <TheGroceryFormControls v-on:form-submitted="submitForm"></TheGroceryFormControls>
+    <TheGroceryFormControls></TheGroceryFormControls>
   </form>
 </template>
 
 <script>
-import axios from "axios";
-import { mapState, mapGetters, mapActions } from "vuex";
+import { mapState, mapActions } from "vuex";
 
 import GroceryFormItem from "./GroceryFormItem.vue";
 import TheGroceryFormControls from "./TheGroceryFormControls.vue";
 
 export default {
-  data() {
-    return {};
-  },
   components: {
     GroceryFormItem,
     TheGroceryFormControls
   },
   computed: {
-    ...mapState(["allPossibleGroceryItems"]),
-    ...mapGetters(["emailBody"])
+    ...mapState(["allPossibleGroceryItems"])
   },
   methods: {
-    ...mapActions(["setAllPossibleGroceryItems"]),
-    submitForm() {
-      console.log("now `submitForm()` is in control!");
-      axios
-        .post("https://groceries-vue-api.glitch.me/submit", {
-          html: this.emailBody
-        })
-        .then(console.log("axios.post just posted HELLO WORLD!"))
-        .then(this.$router.push("/submit"))
-        .catch(error => {
-          console.log("ERROR! ->", error);
-        });
-    }
+    ...mapActions(["setAllPossibleGroceryItems"])
   },
   created() {
     this.setAllPossibleGroceryItems();

--- a/src/components/GroceryForm/TheGroceryFormControls.vue
+++ b/src/components/GroceryForm/TheGroceryFormControls.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-column sm-flex-row justify-between flex-wrap">
     <div class="flex flex-center order-2 sm-order-1">
       <input
-        @click.prevent="$emit('form-submitted')"
+        @click.prevent="submitForm"
         class="btn btn-primary bg-blue fw400"
         type="submit"
         value="submit"
@@ -14,6 +14,9 @@
 </template>
 
 <script>
+import axios from "axios";
+import { mapGetters } from "vuex";
+
 import TheGroceryFormEmailSelector from "./TheGroceryFormEmailSelector.vue";
 import GroceryFormAddItemBtn from "../global/AddItemBtn.vue";
 
@@ -21,6 +24,22 @@ export default {
   components: {
     TheGroceryFormEmailSelector,
     GroceryFormAddItemBtn
+  },
+  computed: {
+    ...mapGetters(["emailBody"])
+  },
+  methods: {
+    submitForm() {
+      axios
+        .post("https://groceries-vue-api.glitch.me/submit", {
+          html: this.emailBody
+        })
+        .then(console.log("axios.post just posted HELLO WORLD!"))
+        .then(this.$router.push("/submit"))
+        .catch(error => {
+          console.log("ERROR! ->", error);
+        });
+    }
   }
 };
 </script>


### PR DESCRIPTION
This PR:

- updates `TheGroceryFormControls.vue` and `TheGroceryForm.vue` to use vuex to submit the form from the child controls, instead of from the parent form using custom events
- closes #11 