### PR TITLE
Populate item form with existing item data to edit data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,3 +39,4 @@ This document started at v0.7.0, via the `itemForm` branch.
 - ending v: v0.9.0
 - steps:
   - create new getter that returns a function that accepts an item \_id, and uses the \_id to query all grocery items to return the current item to display in the edit item route.
+  - change the scope of the item form state via its name, ie: `newItem` to `itemFormItem`. Whereas the former scope is only about new items, the latter allows for both new and existing items.

--- a/changelog.md
+++ b/changelog.md
@@ -31,3 +31,9 @@ This document started at v0.7.0, via the `itemForm` branch.
 - starting point: v0.8.1
 - ending point: v0.8.2
 - refactor `TheGroceryForm.vue` and `TheGroceryFormControls.vue` to use vuex to submit form from the form controls instead of using custom events to submit via the form parent.
+
+4. Use `ItemForm` to display existing item data (ie: use ItemForm not just to add a new item to the db, but to display an existing item's data)
+
+- starting branch: show-item-data-in-item-form
+- starting v: v0.8.2
+- ending v: v0.9.0

--- a/changelog.md
+++ b/changelog.md
@@ -37,3 +37,5 @@ This document started at v0.7.0, via the `itemForm` branch.
 - starting branch: show-item-data-in-item-form
 - starting v: v0.8.2
 - ending v: v0.9.0
+- steps:
+  - create new getter that returns a function that accepts an item \_id, and uses the \_id to query all grocery items to return the current item to display in the edit item route.

--- a/changelog.md
+++ b/changelog.md
@@ -40,3 +40,4 @@ This document started at v0.7.0, via the `itemForm` branch.
 - steps:
   - create new getter that returns a function that accepts an item \_id, and uses the \_id to query all grocery items to return the current item to display in the edit item route.
   - change the scope of the item form state via its name, ie: `newItem` to `itemFormItem`. Whereas the former scope is only about new items, the latter allows for both new and existing items.
+  - need to reset `itemFormItem` state on route change (reset when go to '/')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Rewrite of my groceries web app in Vue and Parcel",
   "main": "index.pug",
   "scripts": {

--- a/src/components/GroceryForm/GroceryFormItem.vue
+++ b/src/components/GroceryForm/GroceryFormItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="item">
-    <GroceryFormItemEditLink></GroceryFormItemEditLink>
+    <GroceryFormItemEditLink :_id="item._id"></GroceryFormItemEditLink>
 
     <GroceryFormItemCheckboxInput :slug="item.slug"></GroceryFormItemCheckboxInput>
 

--- a/src/components/GroceryForm/GroceryFormItemEditLink.vue
+++ b/src/components/GroceryForm/GroceryFormItemEditLink.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link
-    :to="`/edit/${id}`"
+    :to="`/edit/${_id}`"
     class="w-16px flex flex-center mx1 sm-mx2 grey"
   >
     <!-- <i class="far fa-edit"></i> -->
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  props: ["id"]
+  props: ["_id"]
 };
 </script>

--- a/src/components/ItemForm/ItemStoreAreaInput.vue
+++ b/src/components/ItemForm/ItemStoreAreaInput.vue
@@ -15,18 +15,18 @@ import { mapState, mapActions } from "vuex";
 export default {
   props: ["store"],
   computed: {
-    ...mapState(["newItem"]),
+    ...mapState(["itemFormItem"]),
     input: {
       get() {
-        return this.newItem[`${this.capFirstLetter(this.store)}Area`];
+        return this.itemFormItem[`${this.capFirstLetter(this.store)}Area`];
       },
       set(payload) {
-        this[`setNewItem${this.capFirstLetter(this.store)}Area`](payload);
+        this[`setItemFormItem${this.capFirstLetter(this.store)}Area`](payload);
       }
     }
   },
   methods: {
-    ...mapActions(["setNewItemTjArea", "setNewItemMomsArea"]),
+    ...mapActions(["setItemFormItemTjArea", "setItemFormItemMomsArea"]),
     capFirstLetter(string) {
       return `${string.slice(0, 1).toUpperCase()}${string.slice(1)}`;
     }

--- a/src/components/ItemForm/ItemStoreAreaInput.vue
+++ b/src/components/ItemForm/ItemStoreAreaInput.vue
@@ -5,7 +5,7 @@
     :name="`${store}Area`"
     class="block field w-90px mb2"
     type="number"
-    v-model="input"
+    v-model.number="input"
   >
 </template>
 
@@ -18,7 +18,7 @@ export default {
     ...mapState(["itemFormItem"]),
     input: {
       get() {
-        return this.itemFormItem[`${this.capFirstLetter(this.store)}Area`];
+        return this.itemFormItem[`${this.store}Area`];
       },
       set(payload) {
         this[`setItemFormItem${this.capFirstLetter(this.store)}Area`](payload);

--- a/src/components/ItemForm/TheItemDefaultStoreSelector.vue
+++ b/src/components/ItemForm/TheItemDefaultStoreSelector.vue
@@ -32,18 +32,18 @@ export default {
     };
   },
   computed: {
-    ...mapState(["storesRef", "newItem"]),
+    ...mapState(["storesRef", "itemFormItem"]),
     selection: {
       get() {
-        return this.newItem.defaultStore;
+        return this.itemFormItem.defaultStore;
       },
       set(payload) {
-        this.setNewItemDefaultStore(payload);
+        this.setItemFormItemDefaultStore(payload);
       }
     }
   },
   methods: {
-    ...mapActions(["setNewItemDefaultStore"])
+    ...mapActions(["setItemFormItemDefaultStore"])
   }
 };
 </script>

--- a/src/components/ItemForm/TheItemForm.vue
+++ b/src/components/ItemForm/TheItemForm.vue
@@ -26,7 +26,16 @@ export default {
     TheItemFormControls
   },
   computed: {
-    ...mapGetters(["itemFormTjOrMomsIsSelected"])
+    ...mapGetters(["itemFormTjOrMomsIsSelected", "currentItem"])
+  },
+  created() {
+    const vm = this;
+    console.log("HEREs the THIS MOTHERFUCKER:::::", this);
+    console.log("this.$route.params._id", this.$route.params._id);
+    console.log(
+      "here comes the curentItem!!!",
+      vm.currentItem(vm.$route.params._id)
+    );
   }
 };
 </script>

--- a/src/components/ItemForm/TheItemForm.vue
+++ b/src/components/ItemForm/TheItemForm.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 
 import TheItemNameInput from "./TheItemNameInput.vue";
 import TheItemStoresSelector from "./TheItemStoresSelector.vue";
@@ -28,14 +28,13 @@ export default {
   computed: {
     ...mapGetters(["itemFormTjOrMomsIsSelected", "currentItem"])
   },
+  methods: {
+    ...mapActions(["setItemFormItem"])
+  },
   created() {
-    const vm = this;
-    console.log("HEREs the THIS MOTHERFUCKER:::::", this);
-    console.log("this.$route.params._id", this.$route.params._id);
-    console.log(
-      "here comes the curentItem!!!",
-      vm.currentItem(vm.$route.params._id)
-    );
+    this.$route.name === "edit"
+      ? this.setItemFormItem(this.currentItem(this.$route.params._id)[0])
+      : console.log("$route must NOT be 'edit'");
   }
 };
 </script>

--- a/src/components/ItemForm/TheItemFormContainer.vue
+++ b/src/components/ItemForm/TheItemFormContainer.vue
@@ -7,12 +7,21 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
+
 import TheItemForm from "./TheItemForm.vue";
 
 export default {
   components: {
     TheItemForm
   },
-  props: ["heading"]
+  computed: {
+    ...mapGetters(["currentItem"]),
+    heading() {
+      return this.$route.name === "add"
+        ? `add item`
+        : `edit ${this.currentItem(this.$route.params._id)[0].name}`;
+    }
+  }
 };
 </script>

--- a/src/components/ItemForm/TheItemFormControls.vue
+++ b/src/components/ItemForm/TheItemFormControls.vue
@@ -13,12 +13,12 @@ import { mapState } from "vuex";
 
 export default {
   computed: {
-    ...mapState(["newItem"])
+    ...mapState(["itemFormItem"])
   },
   methods: {
     post() {
       axios
-        .post("https://groceries-vue-api.glitch.me/create", this.newItem)
+        .post("https://groceries-vue-api.glitch.me/create", this.itemFormItem)
         .then(this.$router.push("/"))
         .catch(error => {
           console.log("ERROR!:::", error);

--- a/src/components/ItemForm/TheItemNameInput.vue
+++ b/src/components/ItemForm/TheItemNameInput.vue
@@ -24,18 +24,18 @@ import { mapState, mapActions } from "vuex";
 
 export default {
   computed: {
-    ...mapState(["newItem"]),
+    ...mapState(["itemFormItem"]),
     name: {
       get() {
-        return this.newItem.name;
+        return this.itemFormItem.name;
       },
       set(payload) {
-        this.setNewItemName(payload);
+        this.setItemFormItemName(payload);
       }
     }
   },
   methods: {
-    ...mapActions(["setNewItemName"])
+    ...mapActions(["setItemFormItemName"])
   }
 };
 </script>

--- a/src/components/ItemForm/TheItemStoresSelector.vue
+++ b/src/components/ItemForm/TheItemStoresSelector.vue
@@ -32,13 +32,13 @@ export default {
     };
   },
   computed: {
-    ...mapState(["storesRef", "newItem"]),
+    ...mapState(["storesRef", "itemFormItem"]),
     selection: {
       get() {
-        return this.newItem.stores;
+        return this.itemFormItem.stores;
       },
       set(payload) {
-        this.setNewItemStores(payload);
+        this.setItemFormItemStores(payload);
       }
     },
     tjIsSelected() {
@@ -50,7 +50,7 @@ export default {
   },
   methods: {
     ...mapActions([
-      "setNewItemStores",
+      "setItemFormItemStores",
       "setItemFormStoresTjIsSelected",
       "setItemFormStoresMomsIsSelected"
     ])

--- a/src/router.js
+++ b/src/router.js
@@ -17,7 +17,7 @@ const routes = [
     props: { heading: 'add item' }
   },
   {
-    path: '/edit/:id',
+    path: '/edit/:_id',
     name: 'edit',
     component: TheItemFormContainer,
     props: { heading: 'edit item' }

--- a/src/router.js
+++ b/src/router.js
@@ -20,7 +20,7 @@ const routes = [
     path: '/edit/:id',
     name: 'edit',
     component: TheItemFormContainer,
-    props: { heading: 'edit' }
+    props: { heading: 'edit item' }
   },
   {
     path: '/submit',

--- a/src/router.js
+++ b/src/router.js
@@ -13,14 +13,12 @@ const routes = [
   {
     path: '/add',
     name: 'add',
-    component: TheItemFormContainer,
-    props: { heading: 'add item' }
+    component: TheItemFormContainer
   },
   {
     path: '/edit/:_id',
     name: 'edit',
-    component: TheItemFormContainer,
-    props: { heading: 'edit item' }
+    component: TheItemFormContainer
   },
   {
     path: '/submit',

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -33,28 +33,28 @@ export const removeItemFromUserSelectedItems = ({ commit }, payload) => {
 };
 
 // ItemForm actions
-export const resetNewItem = ({ commit }) => {
-  commit('RESET_NEW_ITEM');
+export const resetItemFormItem = ({ commit }) => {
+  commit('RESET_ITEM_FORM_ITEM');
 };
 
-export const setNewItemName = ({ commit }, payload) => {
-  commit('SET_NEW_ITEM_NAME', payload);
+export const setItemFormItemName = ({ commit }, payload) => {
+  commit('SET_ITEM_FORM_ITEM_NAME', payload);
 };
 
-export const setNewItemStores = ({ commit }, payload) => {
-  commit('SET_NEW_ITEM_STORES', payload);
+export const setItemFormItemStores = ({ commit }, payload) => {
+  commit('SET_ITEM_FORM_ITEM_STORES', payload);
 };
 
-export const setNewItemDefaultStore = ({ commit }, payload) => {
-  commit('SET_NEW_ITEM_DEFAULT_STORE', payload);
+export const setItemFormItemDefaultStore = ({ commit }, payload) => {
+  commit('SET_ITEM_FORM_ITEM_DEFAULT_STORE', payload);
 };
 
-export const setNewItemTjArea = ({ commit }, payload) => {
-  commit('SET_NEW_ITEM_TJ_AREA', payload);
+export const setItemFormItemTjArea = ({ commit }, payload) => {
+  commit('SET_ITEM_FORM_ITEM_TJ_AREA', payload);
 };
 
-export const setNewItemMomsArea = ({ commit }, payload) => {
-  commit('SET_NEW_ITEM_MOMS_AREA', payload);
+export const setItemFormItemMomsArea = ({ commit }, payload) => {
+  commit('SET_ITEM_FORM_ITEM_MOMS_AREA', payload);
 };
 
 export const setItemFormStoresTjIsSelected = ({ commit }, payload) => {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -37,6 +37,10 @@ export const resetItemFormItem = ({ commit }) => {
   commit('RESET_ITEM_FORM_ITEM');
 };
 
+export const setItemFormItem = ({ commit }, payload) => {
+  commit('SET_ITEM_FORM_ITEM', payload);
+};
+
 export const setItemFormItemName = ({ commit }, payload) => {
   commit('SET_ITEM_FORM_ITEM_NAME', payload);
 };

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -123,3 +123,7 @@ export const itemFormTjOrMomsIsSelected = state => {
     ? true
     : false;
 };
+
+export const currentItem = state => _id => {
+  return state.allPossibleGroceryItems.filter(item => item._id === _id);
+};

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -43,6 +43,12 @@ export const RESET_ITEM_FORM_ITEM = state => {
 
 export const SET_ITEM_FORM_ITEM = (state, payload) => {
   Vue.set(state, 'itemFormItem', payload);
+  payload.tjArea != null
+    ? Vue.set(state, 'itemFormStoresTjIsSelected', true)
+    : null;
+  payload.momsArea != null
+    ? Vue.set(state, 'itemFormStoresMomsIsSelected', true)
+    : null;
 };
 
 export const SET_ITEM_FORM_ITEM_NAME = (state, payload) => {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -31,8 +31,8 @@ export const REMOVE_ITEM_FROM_USER_SELECTED_ITEMS = (state, payload) => {
 /* ItemForm mutations */
 
 // SET
-export const RESET_NEW_ITEM = state => {
-  Vue.set(state, 'newItem', {
+export const RESET_ITEM_FORM_ITEM = state => {
+  Vue.set(state, 'itemFormItem', {
     name: '',
     stores: [],
     tjArea: null,
@@ -41,24 +41,24 @@ export const RESET_NEW_ITEM = state => {
   });
 };
 
-export const SET_NEW_ITEM_NAME = (state, payload) => {
-  Vue.set(state.newItem, 'name', payload);
+export const SET_ITEM_FORM_ITEM_NAME = (state, payload) => {
+  Vue.set(state.itemFormItem, 'name', payload);
 };
 
-export const SET_NEW_ITEM_STORES = (state, payload) => {
-  Vue.set(state.newItem, 'stores', payload);
+export const SET_ITEM_FORM_ITEM_STORES = (state, payload) => {
+  Vue.set(state.itemFormItem, 'stores', payload);
 };
 
-export const SET_NEW_ITEM_DEFAULT_STORE = (state, payload) => {
-  Vue.set(state.newItem, 'defaultStore', payload);
+export const SET_ITEM_FORM_ITEM_DEFAULT_STORE = (state, payload) => {
+  Vue.set(state.itemFormItem, 'defaultStore', payload);
 };
 
-export const SET_NEW_ITEM_TJ_AREA = (state, payload) => {
-  Vue.set(state.newItem, 'tjArea', payload);
+export const SET_ITEM_FORM_ITEM_TJ_AREA = (state, payload) => {
+  Vue.set(state.itemFormItem, 'tjArea', payload);
 };
 
-export const SET_NEW_ITEM_MOMS_AREA = (state, payload) => {
-  Vue.set(state.newItem, 'momsArea', payload);
+export const SET_ITEM_FORM_ITEM_MOMS_AREA = (state, payload) => {
+  Vue.set(state.itemFormItem, 'momsArea', payload);
 };
 
 export const SET_ITEM_FORM_STORES_TJ_IS_SELECTED = state => {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -41,6 +41,10 @@ export const RESET_ITEM_FORM_ITEM = state => {
   });
 };
 
+export const SET_ITEM_FORM_ITEM = (state, payload) => {
+  Vue.set(state, 'itemFormItem', payload);
+};
+
 export const SET_ITEM_FORM_ITEM_NAME = (state, payload) => {
   Vue.set(state.itemFormItem, 'name', payload);
 };

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -35,7 +35,7 @@ export const storesAreasRef = {
   }
 };
 
-export const newItem = {
+export const itemFormItem = {
   name: '',
   stores: [],
   tjArea: null,


### PR DESCRIPTION
This PR populates the `TheItemForm` with data from an existing item to edit that item's data.

**NOTE**: the actual saving/editing data functionality is still missing, and should be the focus of a next feature branch.

Closes #17.