### PR TITLE
Fix tj moms is selected bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Rewrite of my groceries web app in Vue and Parcel",
   "main": "index.pug",
   "scripts": {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -77,18 +77,10 @@ export const SET_ITEM_FORM_ITEM_MOMS_AREA = (state, payload) => {
   Vue.set(state.itemFormItem, 'momsArea', payload);
 };
 
-export const SET_ITEM_FORM_STORES_TJ_IS_SELECTED = state => {
-  Vue.set(
-    state,
-    'itemFormStoresTjIsSelected',
-    !state.itemFormStoresTjIsSelected
-  );
+export const SET_ITEM_FORM_STORES_TJ_IS_SELECTED = (state, payload) => {
+  Vue.set(state, 'itemFormStoresTjIsSelected', payload);
 };
 
-export const SET_ITEM_FORM_STORES_MOMS_IS_SELECTED = state => {
-  Vue.set(
-    state,
-    'itemFormStoresMomsIsSelected',
-    !state.itemFormStoresMomsIsSelected
-  );
+export const SET_ITEM_FORM_STORES_MOMS_IS_SELECTED = (state, payload) => {
+  Vue.set(state, 'itemFormStoresMomsIsSelected', payload);
 };


### PR DESCRIPTION
This PR fixes the bug that was causing the item stores areas part of the itemForm to show up when a user viewed existing item data, then clicked the add item button. Instead of a totally blank form, tj or moms is selected state was wrong, and showing the stores areas section.

Correctly leveraging the `payload` param in the mutations fixed the bug!